### PR TITLE
Handling json parser error in json error response

### DIFF
--- a/lib/Google/BigQuery.pm
+++ b/lib/Google/BigQuery.pm
@@ -84,8 +84,19 @@ sub _auth {
   if ($response->is_success) {
     $self->{access_token} = decode_json($response->decoded_content);
   } else {
-    my $error = decode_json($response->decoded_content);
-    die $error->{error};
+
+    my $jsonerror;
+    eval {
+        $jsonerror = decode_json($response->decoded_content);
+    };
+    if ($@) {
+	my $err = $@;
+	chomp($err);
+	die("Got error '$err' when decoding json respons:\n'" . $response->decoded_content);
+    }
+
+    die $jsonerror->{error};
+
   }
 }
 


### PR DESCRIPTION
Patch for handling json parser error in the json error response.

**Instead of this:**

*malformed JSON string, neither tag, array, object, number, string or atom, at character offset 0 (before "Can't verify SSL pee...") at /Users/runarb/modules/Google/BigQuery.pm line 87.*


**You get this:**


*Got error 'malformed JSON string, neither tag, array, object, number, string or atom, at character offset 0 (before "Can't verify SSL pee...") at /Users/runarb/modules/Google/BigQuery.pm line 90.' when decoding json respons:*
*'Can't verify SSL peers without knowing which Certificate Authorities to trust*

*This problem can be fixed by either setting the PERL_LWP_SSL_CA_FILE
envirionment variable or by installing the Mozilla::CA module.*

*To disable verification of SSL peers set the PERL_LWP_SSL_VERIFY_HOSTNAME
envirionment variable to 0.  If you do this you can't be sure that you
communicate with the expected peer.*