### PR TITLE
provide an option to use standard SQL

### DIFF
--- a/lib/Google/BigQuery.pm
+++ b/lib/Google/BigQuery.pm
@@ -618,6 +618,7 @@ sub selectrow_array {
 
   my $content = {
     query => $query,
+    useLegacySql => $args{useLegacySql} // 'true'
   };
 
   # option
@@ -642,7 +643,11 @@ sub selectrow_array {
   $self->{response} = $response;
 
   if (defined $response->{error}) {
-    warn $response->{error}{message};
+    if ($response->{error}{message}=~/Try using standard SQL/) {
+      warn "add useLegacySql=>'false'";
+    } else {
+      warn $response->{error}{message};
+    }
     return 0;
   }
 
@@ -672,6 +677,7 @@ sub selectall_arrayref {
 
   my $content = {
     query => $query,
+    useLegacySql => $args{useLegacySql} // 'true'
   };
 
   # option
@@ -696,7 +702,11 @@ sub selectall_arrayref {
   $self->{response} = $response;
 
   if (defined $response->{error}) {
-    warn $response->{error}{message};
+    if ($response->{error}{message}=~/Try using standard SQL/) {
+      warn "add useLegacySql=>'false'";
+    } else {
+      warn $response->{error}{message};
+    }
     return 0;
   }
 
@@ -1205,6 +1215,7 @@ Select a row.
   $bq->selectrow_array(           # return array of a row
     project_id => $project_id,    # required if default project is not set
     query => $query,              # required
+    useLegacySql => $boolean,     # optional (default: true)
     dataset_id => $dataset_id,    # optional
     maxResults => $maxResults,    # optional
     timeoutMs => $timeoutMs,      # optional
@@ -1219,6 +1230,7 @@ Select rows.
   $bq->selectrow_array(           # return arrayref of rows
     project_id => $project_id,    # required if default project is not set
     query => $query,              # required
+    useLegacySql => $boolean,     # optional (default: true)
     dataset_id => $dataset_id,    # optional
     maxResults => $maxResults,    # optional
     timeoutMs => $timeoutMs,      # optional

--- a/t/07_db_methods.t
+++ b/t/07_db_methods.t
@@ -108,10 +108,19 @@ unlink $load_file;
 my ($count) = $bigquery->selectrow_array(query => "SELECT COUNT(*) FROM $table_id");
 is($count, 43, "SELECT COUNT(*) FROM $table_id");
 
+# selectrow_array (standard SQL)
+my ($count) = $bigquery->selectrow_array(query => "SELECT COUNT(*) FROM $table_id", useLegacySql => 'false');
+is($count, 43, "SELECT COUNT(*) FROM $table_id (standard SQL)");
+
 # selectall_arrayref
 my $aref = $bigquery->selectall_arrayref(query => "SELECT * FROM $table_id");
 is(scalar @{$aref}, 43, "SELECT * FROM $table_id (number of rows)");
 is(scalar @{$aref->[0]}, 2, "SELECT * FROM $table_id (number of fields)");
+
+# selectall_arrayref (standard SQL)
+my $aref = $bigquery->selectall_arrayref(query => "SELECT * FROM $table_id", useLegacySql => 'false');
+is(scalar @{$aref}, 43, "SELECT * FROM $table_id (number of rows) (standard SQL)");
+is(scalar @{$aref->[0]}, 2, "SELECT * FROM $table_id (number of fields) (standard SQL)");
 
 # drop table
 $ret = $bigquery->drop_table(table_id => $table_id);


### PR DESCRIPTION
Hi,

My project requires standard SQL to do something like "SELECT TIMESTAMP "2019-10-20 00:00:00" . so I've created this patch to provide an additional option to use standard SQL.
for example:

# this will result an error
$bq->selectrow_array(query => 'SELECT TIMESTAMP "2019-10-20 00:00:00"');

# this will work
$bq->selectrow_array(query => 'SELECT TIMESTAMP "2019-10-20 00:00:00"', useLegacySql=>'false');

default is still legacy sql (useLegacySql=true as https://cloud.google.com/bigquery/docs/reference/rest/v2/Job ), so there should be no compatibility issue.

thanks for the great Google::BigQuery!