### PR TITLE
capture latest http response in $self for use in debugging

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for Perl extension Google-BigQuery
 
 {{$NEXT}}
 
+1.03 2022-03-16T22:57:00Z
+
+    - store latest http response in $self for debugging purposes
+
 1.02 2015-07-30T05:03:02Z
 
     - Fix typo viersion number.

--- a/lib/Google/BigQuery.pm
+++ b/lib/Google/BigQuery.pm
@@ -3,7 +3,7 @@ use 5.010001;
 use strict;
 use warnings;
 
-our $VERSION = "1.02";
+our $VERSION = "1.03";
 
 use Class::Load qw(load_class);
 use Crypt::OpenSSL::PKCS12;
@@ -76,7 +76,7 @@ sub _auth {
 
   my $jwt = JSON::WebToken::encode_jwt($claim, $self->{private_key}, 'RS256', { type => 'JWT' });
 
-  my $response = $self->{ua}->post(
+  my $response = $self->{response} = $self->{ua}->post(
     $self->{GOOGLE_API_TOKEN_URI},
     { grant_type => $self->{GOOGLE_API_GRANT_TYPE}, assertion => $jwt }
   );
@@ -91,7 +91,7 @@ sub _auth {
 
 sub _set_rest_description {
   my ($self) = @_;
-  my $response = $self->{ua}->get($self->{GOOGLE_BIGQUERY_REST_DESCRIPTION});
+  my $response = $self->{response} = $self->{ua}->get($self->{GOOGLE_BIGQUERY_REST_DESCRIPTION});
   $self->{rest_description} = decode_json($response->decoded_content);
 }
 

--- a/lib/Google/BigQuery/V2.pm
+++ b/lib/Google/BigQuery/V2.pm
@@ -86,7 +86,7 @@ sub request {
       );
     }
 
-    my $response = $self->{ua}->request($request);
+    my $response = $self->{response} = $self->{ua}->request($request);
     if (defined $response->content) {
       my $content = decode_json($response->content);
       if (defined $content->{error}) {
@@ -127,7 +127,7 @@ sub request {
       $request->header('Content-Type' => 'application/json');
       $request->content(encode_json($args{content}));
     }
-    my $response = $self->{ua}->request($request);
+    my $response = $self->{response} = $self->{ua}->request($request);
 
     if ($response->code == 204) {
       return {};


### PR DESCRIPTION
Hello team,

I have a customer who is unable to determine the HTTP response code of a failed request.  This change will allow them to wrap the failing call in an eval { ... } and inspect $bq->{response}->status_line to determine the code.

Let me know if you'd like any other changes to go in to this.

Cheers,

C.J.
